### PR TITLE
fix(builtin): patched methods accept Buffer and URL types

### DIFF
--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -341,6 +341,15 @@ jasmine_node_test(
     ],
 )
 
+jasmine_node_test(
+    name = "patches_test",
+    srcs = ["patches.spec.js"],
+    data = [
+        "dir_output",
+        "minified.js",
+    ],
+)
+
 [nodejs_toolchain_test(
     name = "nodejs_toolchain_%s_test" % platform,
     platform = platform,

--- a/internal/node/test/patches.spec.js
+++ b/internal/node/test/patches.spec.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+
+describe('node fs function does not throw:', () => {
+    const files = runfiles.resolvePackageRelative('dir_output')
+    const filesBuf = Buffer.from(files);
+    const filesUrl = new URL('file://' + files);
+    const doNothingCallback = () => {}
+    
+    // listed in order of appearance in the patch file
+    it('lstat', () => {
+        expect(() => fs.lstat(files, doNothingCallback)).not.toThrow();
+        expect(() => fs.lstat(filesBuf, doNothingCallback)).not.toThrow();
+        expect(() => fs.lstat(filesUrl, doNothingCallback)).not.toThrow();
+    });
+    
+    it('realpath', () => {
+        expect(() => fs.realpath(files, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.realpath(filesBuf, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.realpath(filesUrl, undefined, doNothingCallback)).not.toThrow();
+    });
+    
+    it('realpath.native', () => {
+        expect(() => fs.realpath.native(files, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.realpath.native(filesBuf, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.realpath.native(filesUrl, undefined, doNothingCallback)).not.toThrow();
+    });
+    
+    it('readlink', () => {
+        expect(() => fs.readlink(files, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.readlink(filesBuf, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.readlink(filesUrl, undefined, doNothingCallback)).not.toThrow();
+    });
+    
+    it('lstatSync', () => {
+        expect(() => fs.lstatSync(files)).not.toThrow();
+        expect(() => fs.lstatSync(filesBuf)).not.toThrow();
+        expect(() => fs.lstatSync(filesUrl)).not.toThrow();
+    });
+
+    it('realpathSync', () => {
+        expect(() => fs.realpathSync(files)).not.toThrow();
+        expect(() => fs.realpathSync(filesBuf)).not.toThrow();
+        expect(() => fs.realpathSync(filesUrl)).not.toThrow();
+    });
+    
+    it('realpathSync.native', () => {
+        expect(() => fs.realpathSync.native(files)).not.toThrow();
+        expect(() => fs.realpathSync.native(filesBuf)).not.toThrow();
+        expect(() => fs.realpathSync.native(filesUrl)).not.toThrow();
+    });
+    
+    it('readlinkSync', () => {
+        const symlinkPath = path.join(files, 'symlink');
+        fs.symlinkSync(files, symlinkPath);
+        const symlinkPathBuf = Buffer.from(symlinkPath);
+        const symlinkPathUrl = new URL(`file://${symlinkPath}`);
+        expect(() => fs.readlinkSync(symlinkPath)).not.toThrow();
+        expect(() => fs.readlinkSync(symlinkPathBuf)).not.toThrow();
+        expect(() => fs.readlinkSync(symlinkPathUrl)).not.toThrow();
+    });
+
+    it('readdir', () => {
+        expect(() => fs.readdir(files, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.readdir(filesBuf, undefined, doNothingCallback)).not.toThrow();
+        expect(() => fs.readdir(filesUrl, undefined, doNothingCallback)).not.toThrow();
+    });
+    
+    it('readdirSync', () => {
+        expect(() => fs.readdirSync(files)).not.toThrow();
+        expect(() => fs.readdirSync(filesBuf)).not.toThrow();
+        expect(() => fs.readdirSync(filesUrl)).not.toThrow();
+    });
+
+});


### PR DESCRIPTION
The node specification for `fs` methods lists possible types for `path` as string | Buffer | URL. However, because the `path.resolve` and `path.dirname` methods only accept strings, the patched `fs` methods errored if the path arg was a Buffer or URL. This would occur when calling `fs.rm`, for example.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When calling the patched node `fs` methods with a URL or Buffer paths, they error because they can only handle strings. This is not consistent with Node's specification for these methods.

Issue Number: N/A


## What is the new behavior?
The patched `fs` methods can handle URL or Buffer paths.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

