### PR TITLE
More runfiles + Bazel 8 changes

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -86,9 +86,13 @@ else
     fi
   done
 
-  if [[ -z "$RUNFILES" ]]; then
-    echo " >>>> FAIL: RUNFILES environment variable is not set. <<<<" >&2
-    exit 1
+  if [[ -z "${RUNFILES:-}" ]]; then
+    if [[ -d "${RUNFILES_DIR:-/dev/null}" ]]; then
+      RUNFILES=${RUNFILES_DIR}
+    else
+      echo " >>>> FAIL: RUNFILES environment variable is not set. <<<<" >&2
+      exit 1
+    fi
   fi
 fi
 export RUNFILES
@@ -289,7 +293,7 @@ if [[ "${RUNFILES_ROOT}" ]]; then
   # (e.g., /private/.../execroot/build_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/internal/linker/test/multi_linker/test.sh.runfiles/build_bazel_rules_nodejs/node_modules)
   export BAZEL_PATCH_ROOTS="${BAZEL_PATCH_ROOTS},${RUNFILES_ROOT}/${BAZEL_WORKSPACE}/node_modules"
 fi
-if [[ "${RUNFILES}" ]]; then
+if [[ -n "${RUNFILES:-}" ]]; then
   # If in runfiles, guard the RUNFILES root itself
   export BAZEL_PATCH_ROOTS="${BAZEL_PATCH_ROOTS},${RUNFILES}"
   # If RUNFILES is set, guard the RUNFILES node_modules as well


### PR DESCRIPTION
Adds a fallback for `RUNFILES=${RUNFILES_DIR}` when `RUNFILES_DIR` is a directory.