### PR TITLE
fix(builtin): attempt to fix race with package.json and also gather more information

### DIFF
--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -655,6 +655,31 @@ async function findScopes() {
   return scopes;
 }
 
+async function readPackageJsonWithRetry(packageJsonPath: string, maxRetries: number): Promise<any> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let content = ""
+    try {
+      content = await fs.readFile(packageJsonPath, {encoding: 'utf8'});
+      return JSON.parse(stripBom(content));
+    } catch (error: any) {
+      if (error instanceof SyntaxError && attempt < maxRetries) {
+        // Retry after delay in case it was a JSON parse error due to a partial file
+        const delay = (attempt + 1) * 50;
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+      let errorString = `Error reading package.json file. Path ${packageJsonPath}. package.json file content: ${content}.`
+
+      // Re-throw on final attempt or non-syntax errors
+      if (error instanceof Error) {
+        throw Error(errorString + ` Caused by: ${error.stack}`)
+      } else {
+        throw Error(errorString + `Unknown cause: ${error}.`)
+      }
+    }
+  }
+}
+
 /**
  * Given the name of a top-level folder in node_modules, parse the
  * package json and return it as an object along with
@@ -664,7 +689,7 @@ export async function parsePackage(p: string, dependencies: Set<string> = new Se
   // Parse the package.json file of this package
   const packageJson = path.posix.join(p, 'package.json');
   const pkg = (await isFile(packageJson)) ?
-      JSON.parse(stripBom(await fs.readFile(packageJson, {encoding: 'utf8'}))) :
+      await readPackageJsonWithRetry(packageJson, 5) :
       {version: '0.0.0'};
 
   // Trim the leading node_modules from the path and

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -415,10 +415,33 @@ async function findScopes() {
         .filter((f) => typeof f === 'string');
     return scopes;
 }
+async function readPackageJsonWithRetry(packageJsonPath, maxRetries) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        let content = "";
+        try {
+            content = await fs_1.promises.readFile(packageJsonPath, { encoding: 'utf8' });
+            return JSON.parse(stripBom(content));
+        }
+        catch (error) {
+            if (error instanceof SyntaxError && attempt < maxRetries) {
+                const delay = (attempt + 1) * 50;
+                await new Promise(resolve => setTimeout(resolve, delay));
+                continue;
+            }
+            let errorString = `Error reading package.json file. Path ${packageJsonPath}. package.json file content: ${content}.`;
+            if (error instanceof Error) {
+                throw Error(errorString + ` Caused by: ${error.stack}`);
+            }
+            else {
+                throw Error(errorString + `Unknown cause: ${error}.`);
+            }
+        }
+    }
+}
 async function parsePackage(p, dependencies = new Set()) {
     const packageJson = path.posix.join(p, 'package.json');
     const pkg = (await isFile(packageJson)) ?
-        JSON.parse(stripBom(await fs_1.promises.readFile(packageJson, { encoding: 'utf8' }))) :
+        await readPackageJsonWithRetry(packageJson, 5) :
         { version: '0.0.0' };
     pkg._dir = p.substring('node_modules/'.length);
     pkg._name = pkg._dir.split('/').pop();


### PR DESCRIPTION
We're randomly seeing malformed package.json files during a clean build. The package.json files in the repo npm install and npm ci fine. However, rarely during a clean build there will be a SyntaxError about reading a package.json in Bazel land. There seems to be a syntax error in exactly the same place in the same file.

This fix adds a retry with a delay to reading package.json files in case there's any kind of concurrency error. I doubt there is, but who knows.

This also adds extra logging, so we can get more information about what is going on.

