### PR TITLE
fix(runfiles): fixed some issues with temporary directory creation

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -10,34 +10,28 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.main = exports.reduceModules = void 0;
-const crypto = require("crypto");
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 const { runfiles: _defaultRunfiles, _BAZEL_OUT_REGEX } = require('../runfiles/index.js');
 const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
 const createdTemporaryDirectories = new Set();
 function getWriteableRunfilesDirectory(runfilesPath) {
-    const hash = crypto.createHash('sha1').update(runfilesPath).digest('hex').substring(0, 8);
-    const temporaryDirectory = path.join(os.tmpdir(), `runfiles_${hash}`);
+    const temporaryDirectory = fs.mkdtempSync("runfiles_");
     createdTemporaryDirectories.add(temporaryDirectory);
     return temporaryDirectory;
 }
 function deleteTemporaryDirectoriesOnExit() {
-    function handler() {
-        for (const path of createdTemporaryDirectories) {
+    function exitHandler() {
+        createdTemporaryDirectories.forEach((path) => {
             fs.rmSync(path, {
                 recursive: true,
             });
-        }
+        });
         createdTemporaryDirectories.clear();
     }
-    process.on('exit', handler);
-    process.on('SIGINT', handler);
-    process.on('SIGTERM', handler);
-    process.on('SIGUSR1', handler);
-    process.on('SIGUSR2', handler);
-    process.on('uncaughtException', handler);
+    process.on('exit', exitHandler);
+    process.on('SIGINT', () => process.exit(130));
+    process.on('SIGTERM', () => process.exit(143));
 }
 function log_verbose(...m) {
     if (VERBOSE_LOGS)

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -3,9 +3,7 @@
  * and symlinks in the node modules needed to run a program.
  * This replaces the need for custom module resolution logic inside the process.
  */
-import * as crypto from 'crypto';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 // We cannot rely from the linker on the `@bazel/runfiles` package, hence we import from
@@ -26,8 +24,7 @@ const createdTemporaryDirectories = new Set<string>();
  * directory because it's often read-only in remote execution environments.
  */
 function getWriteableRunfilesDirectory(runfilesPath: string): string {
-  const hash = crypto.createHash('sha1').update(runfilesPath).digest('hex').substring(0, 8);
-  const temporaryDirectory = path.join(os.tmpdir(), `runfiles_${hash}`);
+  const temporaryDirectory = fs.mkdtempSync("runfiles_");
 
   createdTemporaryDirectories.add(temporaryDirectory);
 
@@ -35,22 +32,21 @@ function getWriteableRunfilesDirectory(runfilesPath: string): string {
 }
 
 function deleteTemporaryDirectoriesOnExit() {
-  function handler() {
-    for (const path of createdTemporaryDirectories) {
+  function exitHandler() {
+    createdTemporaryDirectories.forEach((path) => {
       fs.rmSync(path, {
         recursive: true,
       });
-    }
+    });
 
     createdTemporaryDirectories.clear();
   }
 
-  process.on('exit', handler);
-  process.on('SIGINT', handler);
-  process.on('SIGTERM', handler);
-  process.on('SIGUSR1', handler);
-  process.on('SIGUSR2', handler);
-  process.on('uncaughtException', handler);
+  process.on('exit', exitHandler);
+
+  // Calling `process.exit` will cause the `exit` event to be fired
+  process.on('SIGINT', () => process.exit(130));
+  process.on('SIGTERM', () => process.exit(143));
 }
 
 function log_verbose(...m: string[]) {

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -4,16 +4,12 @@
 var path = require('path');
 var util = require('util');
 var fs$1 = require('fs');
-var crypto = require('crypto');
-var os = require('os');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
 var path__default = /*#__PURE__*/_interopDefaultLegacy(path);
 var util__default = /*#__PURE__*/_interopDefaultLegacy(util);
 var fs__default = /*#__PURE__*/_interopDefaultLegacy(fs$1);
-var crypto__default = /*#__PURE__*/_interopDefaultLegacy(crypto);
-var os__default = /*#__PURE__*/_interopDefaultLegacy(os);
 
 var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
@@ -544,37 +540,34 @@ exports.patcher = void 0;
 // but adds support to ensure the registered loader is included in all nested executions of nodejs.
 
 
-
-
 const patcher = (requireScriptName, nodeDir) => {
     requireScriptName = path__default['default'].resolve(requireScriptName);
-    if (!nodeDir) {
+    if (nodeDir) {
+        try {
+            fs__default['default'].mkdirSync(nodeDir, { recursive: true });
+        }
+        catch (e) {
+            // with node versions that don't have recursive mkdir this may throw an error.
+            if (e.code !== 'EEXIST') {
+                throw e;
+            }
+        }
+    }
+    else {
         // Write to a temporary directory so we don't write to runfiles, which are often read-only in a
         // remote execution environment
-        const hash = crypto__default['default'].createHash('sha1').update(requireScriptName).digest('hex').substring(0, 8);
-        nodeDir = path__default['default'].join(os__default['default'].tmpdir(), `_node_bin_${hash}`);
-        function cleanUpTemporaryDirectory() {
+        nodeDir = fs__default['default'].mkdtempSync("_node_bin_");
+        function exitHandler() {
             fs__default['default'].rmSync(nodeDir, {
                 recursive: true
             });
         }
-        process.on('exit', cleanUpTemporaryDirectory);
-        process.on('SIGINT', cleanUpTemporaryDirectory);
-        process.on('SIGTERM', cleanUpTemporaryDirectory);
-        process.on('SIGUSR1', cleanUpTemporaryDirectory);
-        process.on('SIGUSR2', cleanUpTemporaryDirectory);
-        process.on('uncaughtException', cleanUpTemporaryDirectory);
+        process.on('exit', exitHandler);
+        // Calling `process.exit` will cause the `exit` event to be fired
+        process.on('SIGINT', () => process.exit(130));
+        process.on('SIGTERM', () => process.exit(143));
     }
     const file = path__default['default'].basename(requireScriptName);
-    try {
-        fs__default['default'].mkdirSync(nodeDir, { recursive: true });
-    }
-    catch (e) {
-        // with node versions that don't have recursive mkdir this may throw an error.
-        if (e.code !== 'EEXIST') {
-            throw e;
-        }
-    }
     if (process.platform == 'win32') {
         const nodeEntry = path__default['default'].join(nodeDir, 'node.bat');
         if (!fs__default['default'].existsSync(nodeEntry)) {

--- a/packages/node-patches/src/subprocess.ts
+++ b/packages/node-patches/src/subprocess.ts
@@ -1,42 +1,38 @@
 // this does not actually patch child_process
 // but adds support to ensure the registered loader is included in all nested executions of nodejs.
-const crypto = require('crypto');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 export const patcher = (requireScriptName: string, nodeDir?: string) => {
   requireScriptName = path.resolve(requireScriptName);
-  if (!nodeDir) {
+  if (nodeDir) {
+    try {
+      fs.mkdirSync(nodeDir, {recursive: true});
+    } catch (e) {
+      // with node versions that don't have recursive mkdir this may throw an error.
+      if (e.code !== 'EEXIST') {
+        throw e;
+      }
+    }
+  } else {
     // Write to a temporary directory so we don't write to runfiles, which are often read-only in a
     // remote execution environment
-    const hash = crypto.createHash('sha1').update(requireScriptName).digest('hex').substring(0, 8);
+    nodeDir = fs.mkdtempSync("_node_bin_");
 
-    nodeDir = path.join(os.tmpdir(), `_node_bin_${hash}`);
-
-    function cleanUpTemporaryDirectory() {
+    function exitHandler() {
       fs.rmSync(nodeDir, {
         recursive: true
       });
     }
 
-    process.on('exit', cleanUpTemporaryDirectory);
-    process.on('SIGINT', cleanUpTemporaryDirectory);
-    process.on('SIGTERM', cleanUpTemporaryDirectory);
-    process.on('SIGUSR1', cleanUpTemporaryDirectory);
-    process.on('SIGUSR2', cleanUpTemporaryDirectory);
-    process.on('uncaughtException', cleanUpTemporaryDirectory);
+    process.on('exit', exitHandler);
+
+    // Calling `process.exit` will cause the `exit` event to be fired
+    process.on('SIGINT', () => process.exit(130));
+    process.on('SIGTERM', () => process.exit(143));
   }
   const file = path.basename(requireScriptName);
 
-  try {
-    fs.mkdirSync(nodeDir, {recursive: true});
-  } catch (e) {
-    // with node versions that don't have recursive mkdir this may throw an error.
-    if (e.code !== 'EEXIST') {
-      throw e;
-    }
-  }
   if (process.platform == 'win32') {
     const nodeEntry = path.join(nodeDir, 'node.bat');
     if (!fs.existsSync(nodeEntry)) {


### PR DESCRIPTION
The directories we were creating weren't random, so it was possible tha two Node actions could share the same directory and one could delete it before the other.

Also, when catching process events like `uncaughtException` and signal events, we need explicitly stop the process (and make sure we return the correct code). In the case of `uncaughtException`, we also need to handle the error thrown in the same way Node.js would've. Doing clean up work seems to be an very difficult problem in Node (hence the existence of `https://github.com/nodejs/node/issues/20804`), so I've decided to just catch `exit` for the time being. Sure, we may leak temporary directories if a certain signal is sent, but I think the risk of not handling signals correctly outweighs the risk of leaking temporary directories.