### PR TITLE
fix(builtin): stop using deprecated @bazel_tools conditions

### DIFF
--- a/internal/common/copy_to_bin.bzl
+++ b/internal/common/copy_to_bin.bzl
@@ -57,9 +57,6 @@ def copy_to_bin(name, srcs, **kwargs):
     _copy_to_bin(
         name = name,
         srcs = srcs,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
+        is_windows = False,
         **kwargs
     )

--- a/internal/common/params_file.bzl
+++ b/internal/common/params_file.bzl
@@ -124,9 +124,6 @@ def params_file(
         args = args,
         data = data,
         newline = newline or "auto",
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
+        is_windows = False,
         **kwargs
     )

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -446,9 +446,6 @@ def js_library(
         # which is still being used in a couple of tests
         # TODO: remove once legacy module_mapping is removed
         module_name = package_name if package_name != "$node_modules$" and package_name != "$node_modules_dir$" else None,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
+        is_windows = False,
         **kwargs
     )

--- a/internal/linker/npm_link.bzl
+++ b/internal/linker/npm_link.bzl
@@ -147,9 +147,6 @@ set to the target's package & the files provided from the targets DefaultInfo.
         deps = [target],
         package_name = package_name,
         package_path = package_path,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
+        is_windows = False,
         **kwargs
     )

--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -120,7 +120,7 @@ If package_path is not set the this will be the root node_modules of the workspa
     ),
     "substitutions": attr.string_dict(
         doc = """Key-value pairs which are replaced in all the files while building the package.
-        
+
 You can use values from the workspace status command using curly braces, for example
 `{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}`.
 
@@ -379,18 +379,12 @@ def pkg_npm_macro(name, tgz = None, **kwargs):
 
     native.alias(
         name = name + ".pack",
-        actual = select({
-            "@bazel_tools//src/conditions:host_windows": name + ".pack.bat",
-            "//conditions:default": name + ".pack.sh",
-        }),
+        actual = name + ".pack.sh",
     )
 
     native.alias(
         name = name + ".publish",
-        actual = select({
-            "@bazel_tools//src/conditions:host_windows": name + ".publish.bat",
-            "//conditions:default": name + ".publish.sh",
-        }),
+        actual = name + ".publish.sh",
     )
 
     if tgz != None:

--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
@@ -208,10 +208,7 @@ def copy_file(name, src, out, is_directory = False, is_executable = False, allow
         name = name,
         src = src,
         out = out,
-        is_windows = select({
-            "@bazel_tools//src/conditions:host_windows": True,
-            "//conditions:default": False,
-        }),
+        is_windows = False,
         is_executable = is_executable,
         allow_symlink = allow_symlink,
         **kwargs

--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/write_file_private.bzl
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/write_file_private.bzl
@@ -94,10 +94,7 @@ def write_file(
             content = content,
             out = out,
             newline = newline or "auto",
-            is_windows = select({
-                "@bazel_tools//src/conditions:host_windows": True,
-                "//conditions:default": False,
-            }),
+            is_windows = False,
             **kwargs
         )
     else:
@@ -106,9 +103,6 @@ def write_file(
             content = content,
             out = out,
             newline = newline or "auto",
-            is_windows = select({
-                "@bazel_tools//src/conditions:host_windows": True,
-                "//conditions:default": False,
-            }),
+            is_windows = False,
             **kwargs
         )

--- a/toolchains/cypress/BUILD.bazel
+++ b/toolchains/cypress/BUILD.bazel
@@ -36,24 +36,14 @@ toolchain_type(name = "toolchain_type")
 # This way they can reference the cypress_PATH make variable.
 alias(
     name = "toolchain",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin": ":cypress_darwin_toolchain_config",
-        "@bazel_tools//src/conditions:linux_x86_64": ":cypress_linux_toolchain_config",
-        "@bazel_tools//src/conditions:windows": ":cypress_windows_toolchain_config",
-        "//conditions:default": ":cypress_linux_toolchain_config",
-    }),
+    actual = ":cypress_linux_toolchain_config",
     visibility = ["//visibility:public"],
 )
 
 # Allow targets to declare a dependency on the cypress binary for the current host platform
 alias(
     name = "cypress_bin",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin": "@cypress_darwin//:bin",
-        "@bazel_tools//src/conditions:linux_x86_64": "@cypress_linux//:bin",
-        "@bazel_tools//src/conditions:windows": "@cypress_windows//:bin",
-        "//conditions:default": "@cypress_linux//:bin",
-    }),
+    actual = "@cypress_linux//:bin",
     visibility = ["//visibility:public"],
 )
 

--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -95,32 +95,14 @@ toolchain_type(
 # This way they can reference the NODE_PATH make variable.
 alias(
     name = "toolchain",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@nodejs_darwin_arm64_config//:toolchain",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64_config//:toolchain",
-        "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64_config//:toolchain",
-        "@bazel_tools//src/conditions:linux_s390x": "@nodejs_linux_s390x_config//:toolchain",
-        "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64_config//:toolchain",
-        "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64_config//:toolchain",
-        "@bazel_tools//src/conditions:linux_ppc64le": "@nodejs_linux_ppc64le_config//:toolchain",
-        "//conditions:default": "@nodejs_linux_amd64_config//:toolchain",
-    }),
+    actual = "@nodejs_linux_amd64_config//:toolchain",
     visibility = ["//visibility:public"],
 )
 
 # Allow targets to declare a dependency on the node binary for the current host platform
 alias(
     name = "node_bin",
-    actual = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@nodejs_darwin_arm64//:node_bin",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64//:node_bin",
-        "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64//:node_bin",
-        "@bazel_tools//src/conditions:linux_s390x": "@nodejs_linux_s390x//:node_bin",
-        "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64//:node_bin",
-        "@bazel_tools//src/conditions:linux_ppc64le": "@nodejs_linux_ppc64le//:node_bin",
-        "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64//:node_bin",
-        "//conditions:default": "@nodejs_linux_amd64//:node_bin",
-    }),
+    actual = "@nodejs_linux_amd64//:node_bin",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
`@bazel_tools//src/conditions` cause an avalanche of warnings in Bazel 8.4