### PR TITLE
fix(typescript): replace absolute path with basename

### DIFF
--- a/packages/typescript/internal/ts_project_options_validator.ts
+++ b/packages/typescript/internal/ts_project_options_validator.ts
@@ -1,4 +1,4 @@
-import {relative} from 'path';
+import {basename, relative} from 'path';
 import * as ts from 'typescript';
 
 const diagnosticsHost: ts.FormatDiagnosticsHost = {
@@ -119,7 +119,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
   // Make the output change whenever the attributes changed.
   require('fs').writeFileSync(
       output, `
-// ${process.argv[1]} checked attributes for ${target}
+// ${basename(process.argv[1])} checked attributes for ${target}
 // allow_js:              ${attrs.allow_js}
 // composite:             ${attrs.composite}
 // declaration:           ${attrs.declaration}


### PR DESCRIPTION
The absolute path is non-deterministic and the basename is deterministic.
